### PR TITLE
Display wallet info in the subscriptions page

### DIFF
--- a/app/components/ActionAndInfo/ActionAndInfo.css
+++ b/app/components/ActionAndInfo/ActionAndInfo.css
@@ -1,0 +1,20 @@
+.actionAndInfo {
+  display: flex;
+  flex-flow: column nowrap;
+  text-align: center;
+
+  & .warningIcon {
+    margin: 0 auto;
+    font-size: 48px;
+    color: var(--color-error);
+  }
+
+  & h2 {
+    color: var(--white);
+  }
+
+  & h3 {
+    color: var(--white);
+    margin-bottom: 20px;
+  }
+}

--- a/app/components/ActionAndInfo/index.tsx
+++ b/app/components/ActionAndInfo/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { PrimaryButton } from '~/components/common/Button';
+import Icon from '~/components/common/Icon';
+
+const ActionAndInfo = () => {
+  const navigate = useNavigate();
+
+  const register = () => {
+    navigate('/register');
+  };
+
+  return (
+    <section className="actionAndInfo">
+      <Icon name="info" className="warningIcon" />
+      <h2>There is no Forgot<br />password option</h2>
+      <h3>If you lose your secret key, no one<br />can restore it. Keep it safe!</h3>
+      <PrimaryButton onClick={register} theme="white">
+        I understand, let&apos;s save password
+      </PrimaryButton>
+    </section>
+  );
+};
+
+export default ActionAndInfo;

--- a/app/components/Modal/index.tsx
+++ b/app/components/Modal/index.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '~/components/common/Button';
 import { ModalProps } from './types';
 
 const Modal = ({
-  discardable = false, theme = 'dark', notStickyInMobile, onDiscard, children, className = '',
+  discardable = false, theme = 'dark', modalRelative, onDiscard, children, className = '',
 }: ModalProps) => {
   const [discarded, setDiscarded] = useState(false);
   const discard = () => {
@@ -17,7 +17,7 @@ const Modal = ({
   };
 
   return (
-    <section className={`component modal ${discarded ? 'discarded' : ''} ${className} ${theme} ${notStickyInMobile ? 'modalRelative' : ''}`}>
+    <section className={`component modal ${discarded ? 'discarded' : ''} ${className} ${theme} ${modalRelative ? 'modalRelative' : ''}`}>
       {
         discardable
           ? (

--- a/app/components/Modal/modal.css
+++ b/app/components/Modal/modal.css
@@ -8,6 +8,14 @@
   box-shadow: 0 -10px 18px 0 var(--color-primary-shadow);
   transition: all ease 200ms;
 
+  &.modalRelative {
+    position: relative !important;
+    box-shadow: 0 -10px 18px 0 var(--color-primary-shadow),
+      0 10px 18px 0 var(--color-primary-shadow);
+    border-radius: var(--border-radius-l);
+    padding-bottom: var(--padding-m);
+  }
+
   &.dark {
     background: var(--color-secondary);
   }
@@ -31,19 +39,5 @@
     transform: translateY(100%);
     opacity: 0;
     pointer-events: none;
-  }
-}
-
-@media (max-width: 480px) {
-
-  .component.modal {
-
-    &.modalRelative {
-      position: relative;
-      box-shadow: 0 -10px 18px 0 var(--color-primary-shadow),
-        0 10px 18px 0 var(--color-primary-shadow);
-      border-radius: var(--border-radius-x);
-      padding-bottom: var(--padding-m);
-    }
   }
 }

--- a/app/components/Modal/types.ts
+++ b/app/components/Modal/types.ts
@@ -6,5 +6,5 @@ export interface ModalProps {
   className?: string;
   children: ReactNode;
   theme?: 'dark' | 'light';
-  notStickyInMobile?: boolean;
+  modalRelative?: boolean;
 }

--- a/app/components/PurchaseSubscription/SubscriptionPlans.tsx
+++ b/app/components/PurchaseSubscription/SubscriptionPlans.tsx
@@ -5,49 +5,59 @@ import { PrimaryButton } from '~/components/common/Button';
 import Feedback from '~/components/Feedback';
 import { fromBaseToken } from '~/helpers/formatters';
 import { SubscriptionPlanProps, SubscriptionPlansProps } from './types';
+import { useAccount } from '~/hooks/useAccount/useAccount';
 
 const SubscriptionPlan = ({
-  data, feedback, onSubmit,
-}: SubscriptionPlanProps) => (
-  <section className="subscriptionPlan">
-    <h3>{data.name || 'Plan name'}</h3>
-    {
-      data.maxMembers === 1
-        ? <h4>For 1 user</h4>
-        : <h4>{`Share it with ${data.maxMembers - 1} ${data.maxMembers === 2 ? 'friend' : 'friends'}`}</h4>
-    }
-    <h3>{fromBaseToken(data.price, TOKEN)}</h3>
-    <PrimaryButton
-      className="subscribeButton"
-      disabled={!!feedback.error || feedback.message !== ''}
-      onClick={onSubmit}
-    >
-      Purchase
-    </PrimaryButton>
-  </section>
-);
+  data, feedback, onSubmit, availableBalance,
+}: SubscriptionPlanProps) => {
+
+  return (
+    <section className="subscriptionPlan">
+      <h3>{data.name || 'Plan name'}</h3>
+      {
+        data.maxMembers === 1
+          ? <h4>For 1 user</h4>
+          : <h4>{`Share it with ${data.maxMembers - 1} ${data.maxMembers === 2 ? 'friend' : 'friends'}`}</h4>
+      }
+      <h3>{fromBaseToken(data.price, TOKEN)}</h3>
+      <PrimaryButton
+        className="subscribeButton"
+        disabled={!!feedback.error || feedback.message !== '' || parseInt(availableBalance) <= parseInt(data.price)}
+        onClick={onSubmit}
+      >
+        Purchase
+      </PrimaryButton>
+    </section>
+  );
+};
 
 const SubscriptionPlans = ({
-  data, feedback, onSubmit
-}: SubscriptionPlansProps) => (
-  <section className="plans">
-    <div className="container">
-      <h2>Pick your plan</h2>
-    </div>
-    <div className="plan-list">
-      {
-        data.map((plan, index) => (
-          <SubscriptionPlan
-            key={index}
-            data={plan}
-            feedback={feedback}
-            onSubmit={onSubmit}
-          />
-        ))
-      }
-    </div>
-    <Feedback data={feedback} />
-  </section>
-);
+  data, feedback, onSubmit,
+}: SubscriptionPlansProps) => {
+  const { info } = useAccount();
+  const availableBalance = info?.token?.length > 0 ? info.token[0].availableBalance : '0';
+
+  return (
+    <section className="plans">
+      <div className="container">
+        <h2>Pick your plan</h2>
+      </div>
+      <div className="plan-list">
+        {
+          data.map((plan, index) => (
+            <SubscriptionPlan
+              key={index}
+              data={plan}
+              feedback={feedback}
+              onSubmit={onSubmit}
+              availableBalance={availableBalance}
+            />
+          ))
+        }
+      </div>
+      <Feedback data={feedback} />
+    </section>
+  );
+};
 
 export default SubscriptionPlans;

--- a/app/components/PurchaseSubscription/types.ts
+++ b/app/components/PurchaseSubscription/types.ts
@@ -3,6 +3,7 @@ import { Subscription } from '~/configs';
 export interface SubscriptionPlanProps {
   data: Subscription;
   onSubmit: () => void;
+  availableBalance: string;
   feedback: {
     error: boolean;
     message: string;

--- a/app/components/WalletDetails/index.tsx
+++ b/app/components/WalletDetails/index.tsx
@@ -3,21 +3,40 @@ import { WalletAddressProps } from './types';
 import CopyButton from '../common/CopyButton';
 import { useAccount } from '~/hooks/useAccount/useAccount';
 import { fromBaseToken } from '~/helpers/formatters';
+import { PrimaryButton } from '~/components/common/Button';
 
-const WalletDetails = ({ address }: WalletAddressProps) => {
+const WalletDetails = ({ showButton = false }: WalletAddressProps) => {
   const { info } = useAccount();
   const availableBalance = info?.token?.length > 0 ? info.token[0].availableBalance : '0';
+
+  const goToTelegram = () => {
+    console.log('telegram');
+  };
 
   return (
     <section className="component walletDetails">
       <header className="walletHeader">
-        <h3 className="walletAddress">{address}</h3>
-        <CopyButton text={address} />
+        <h3 className="walletAddress">{info.address}</h3>
+        <CopyButton text={info.address} />
       </header>
       <div className="balance">
         <span className="balanceTitle">Balance:</span>
         <h2 className="balanceValue">{`${fromBaseToken(availableBalance)} MZK`}</h2>
       </div>
+      <footer className='walletFooter'>
+        {
+          showButton ?
+            <PrimaryButton
+              className='registerButton'
+              theme="white"
+              onClick={goToTelegram}
+            >
+              Get Free Token
+            </PrimaryButton> :
+            null
+        }
+      </footer>
+
     </section>
   );
 };

--- a/app/components/WalletDetails/types.ts
+++ b/app/components/WalletDetails/types.ts
@@ -1,3 +1,3 @@
 export interface WalletAddressProps {
-  address: string;
+  showButton?: boolean;
 }

--- a/app/components/WalletDetails/walletDetails.css
+++ b/app/components/WalletDetails/walletDetails.css
@@ -33,6 +33,10 @@
     }
   }
 
+  & .walletFooter {
+    margin-top: var(--padding-l);
+  }
+
 }
 
 @media (min-width: 1280px) {

--- a/app/routes/__main/profile/$id.tsx
+++ b/app/routes/__main/profile/$id.tsx
@@ -61,7 +61,6 @@ const ProfileScreen = () => {
     profile,
     collections,
     audios,
-    id,
   } = useLoaderData() as ProfileLoaderData;
 
   return (
@@ -75,7 +74,7 @@ const ProfileScreen = () => {
         profile={profile}
       />
       <ProfileDetails data={profile} />
-      <WalletDetails address={id} />
+      <WalletDetails />
     </section>
   );
 };

--- a/app/routes/__main/register/index.tsx
+++ b/app/routes/__main/register/index.tsx
@@ -1,11 +1,10 @@
 /* External dependencies */
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+
 /* Internal dependencies */
-import { PrimaryButton } from '~/components/common/Button';
 import { PartialView } from '~/components/PartialView';
 import { SecretKey } from '~/components/SecretKey';
-import Icon from '~/components/common/Icon';
+import ActionAndInfo from '~/components/ActionAndInfo';
 import styles from '~/css/routes/__main/register.css';
 
 export function links() {
@@ -18,25 +17,6 @@ const SecretKeyGenerator = () => (
     <SecretKey />
   </section>
 );
-
-const ActionAndInfo = () => {
-  const navigate = useNavigate();
-
-  const login = () => {
-    navigate('/login');
-  };
-
-  return (
-    <section className="actionAndInfo">
-      <Icon name="info" className="warningIcon" />
-      <h2>There is no Forgot<br />password option</h2>
-      <h3>If you lose your secret key, no one<br />can restore it. Keep it safe!</h3>
-      <PrimaryButton onClick={login} theme="white">
-        I understand, let&apos;s login
-      </PrimaryButton>
-    </section>
-  );
-};
 
 const RegisterScreen = () => (
   <PartialView

--- a/app/routes/__main/subscription/__main/purchase/index.tsx
+++ b/app/routes/__main/subscription/__main/purchase/index.tsx
@@ -7,17 +7,11 @@ import WalletDetails from '~/components/WalletDetails';
 import ActionAndInfo from '~/components/ActionAndInfo';
 import Modal from '~/components/Modal';
 import {
-  PurchaseLoaderProps,
   PurchaseSubscriptionData,
 } from '~/routes/types';
 import { getSubscriptions } from '~/models/entity.server';
 import { DEV_ACCOUNT, Subscription } from '~/configs';
-import { getSession } from '~/hooks/useSession';
-
-export const loader = async ({ request }: PurchaseLoaderProps) => {
-  const session = await getSession(
-    request.headers.get('Cookie')
-  );
+export const loader = async () => {
 
   const { data: subscriptions } = await getSubscriptions({
     params: {
@@ -39,22 +33,20 @@ export const loader = async ({ request }: PurchaseLoaderProps) => {
   }, {});
 
   return json<PurchaseSubscriptionData>({
-    subscriptionPlans: Object.values(subscriptionPlans),
-    id: session.get('address'),
+    subscriptionPlans: Object.values(subscriptionPlans)
   });
 };
 
 const PurchaseSubscriptionScreen = () => {
   const {
     subscriptionPlans,
-    id,
   } = useLoaderData() as PurchaseSubscriptionData;
 
   return (
     <section className="screen subscription tabContainer">
       <div className='wrap'>
         <section className='wallet'>
-          <WalletDetails address={id} />
+          <WalletDetails showButton={true} />
         </section>
         <section className='warningInfo'>
           <Modal className='modalRelative warning'>

--- a/app/routes/__main/subscription/__main/purchase/index.tsx
+++ b/app/routes/__main/subscription/__main/purchase/index.tsx
@@ -3,16 +3,27 @@ import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 import PurchaseSubscription from '~/components/PurchaseSubscription';
+import WalletDetails from '~/components/WalletDetails';
+import ActionAndInfo from '~/components/ActionAndInfo';
+import Modal from '~/components/Modal';
 import {
+  PurchaseLoaderProps,
   PurchaseSubscriptionData,
 } from '~/routes/types';
 import { getSubscriptions } from '~/models/entity.server';
 import { DEV_ACCOUNT, Subscription } from '~/configs';
+import { getSession } from '~/hooks/useSession';
 
-export const loader = async () => {
-  const { data: subscriptions } = await getSubscriptions({ params: {
-    creatorAddress: DEV_ACCOUNT.ADDRESS,
-  } });
+export const loader = async ({ request }: PurchaseLoaderProps) => {
+  const session = await getSession(
+    request.headers.get('Cookie')
+  );
+
+  const { data: subscriptions } = await getSubscriptions({
+    params: {
+      creatorAddress: DEV_ACCOUNT.ADDRESS,
+    }
+  });
 
   const subscriptionPlans: Record<string, Subscription> = subscriptions.reduce((acc: Record<string, Subscription>, subscription: Subscription) => {
     const {
@@ -29,16 +40,28 @@ export const loader = async () => {
 
   return json<PurchaseSubscriptionData>({
     subscriptionPlans: Object.values(subscriptionPlans),
+    id: session.get('address'),
   });
 };
 
 const PurchaseSubscriptionScreen = () => {
   const {
     subscriptionPlans,
+    id,
   } = useLoaderData() as PurchaseSubscriptionData;
 
   return (
     <section className="screen subscription tabContainer">
+      <div className='wrap'>
+        <section className='wallet'>
+          <WalletDetails address={id} />
+        </section>
+        <section className='warningInfo'>
+          <Modal className='modalRelative warning'>
+            <ActionAndInfo />
+          </Modal>
+        </section>
+      </div>
       <PurchaseSubscription subscriptionPlans={subscriptionPlans} />
     </section>
   );

--- a/app/routes/__main/upload/__main.tsx
+++ b/app/routes/__main/upload/__main.tsx
@@ -1,36 +1,22 @@
 /* External dependencies */
 import React from 'react';
 import { Outlet } from '@remix-run/react';
-import { json } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+
 /* Internal dependencies */
 import styles from '~/css/routes/__main/upload.css';
 import { ROUTES } from '~/routes/routes';
 import { Tabs } from '~/components/common/Tabs';
 import WalletDetails from '~/components/WalletDetails';
-import { UploadLoaderProps, UploadLoaderData } from '../../types';
-import { getSession } from '~/hooks/useSession';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];
 }
 
-export const loader = async ({ request }: UploadLoaderProps) => {
-  const session = await getSession(
-    request.headers.get('Cookie')
-  );
-
-  return json<UploadLoaderData>({
-    id: session.get('address')
-  });
-};
-
 const UploadScreen = () => {
-  const { id } = useLoaderData() as UploadLoaderData;
 
   return (
     <section className="screen upload">
-      <WalletDetails address={id} />
+      <WalletDetails />
       <div className='tab'>
         <header className='tabsHeader'>
           <Tabs

--- a/app/routes/types.ts
+++ b/app/routes/types.ts
@@ -91,13 +91,8 @@ export interface DiscographyProps {
   collections: Collection[];
 }
 
-export interface PurchaseLoaderProps {
-  request: Request;
-}
-
 export interface PurchaseSubscriptionData {
   subscriptionPlans: Awaited<Subscription[]>;
-  id: string;
 }
 
 export interface ActiveSubscriptionData {

--- a/app/routes/types.ts
+++ b/app/routes/types.ts
@@ -91,8 +91,13 @@ export interface DiscographyProps {
   collections: Collection[];
 }
 
+export interface PurchaseLoaderProps {
+  request: Request;
+}
+
 export interface PurchaseSubscriptionData {
   subscriptionPlans: Awaited<Subscription[]>;
+  id: string;
 }
 
 export interface ActiveSubscriptionData {

--- a/styles/routes/__main/register.css
+++ b/styles/routes/__main/register.css
@@ -8,25 +8,4 @@
       margin-top: 30px;
     }
   }
-
-  & .actionAndInfo {
-    display: flex;
-    flex-flow: column nowrap;
-    text-align: center;
-
-    & .warningIcon {
-      margin: 0 auto;
-      font-size: 48px;
-      color: var(--color-error);
-    }
-
-    & h2 {
-      color: var(--white);
-    }
-
-    & h3 {
-      color: var(--white);
-      margin-bottom: 20px;
-    }
-  }
 }

--- a/styles/routes/__main/subscription.css
+++ b/styles/routes/__main/subscription.css
@@ -2,6 +2,31 @@
    position: relative;
    width: 100%;
 
+   & .wrap {
+      position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: stretch;
+      margin-top: 25px;
+      margin-bottom: 75px;
+   }
+   
+   & .wallet {
+      position: relative;
+      width: 40%;
+      margin-right: 10px;
+   }
+
+   & .warningInfo {
+      position: relative;
+      width: 40%;
+      margin-left: 10px;
+   }
+
+   & .walletDetails {
+      height: 100%;
+   }
+
    & > .tabContainer {
       padding: 40px 20px 0;
       box-sizing: border-box;
@@ -12,4 +37,5 @@
       position: relative;
       padding-top: var(--padding-x);
    }
+
 }


### PR DESCRIPTION
### Which issues does this PR address?

Closes #203

### how did you resolve?

- [x] we should display the wallet information in the subscription page.
- [x] we should add a button to the wallet details section to receive free tokens. Said button should navigate users to our Telegram bot.
- [x] we should show a warning to the users for saving the password.
- [x] We should also make sure the purchase buttons are disabled if the balance is not sufficient. If the balance if not sufficient for a subscription plan, we should inform the user with a message under the button.